### PR TITLE
update filter_n_probes logic to drop sequences with "-", fix #11

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -287,7 +287,7 @@ rule filter_n_probes:
         mfree='12G',
         h_rt='3:0:0'
     shell:
-        "awk '$4 !~ /N/' {input} > {output}"
+        "awk '$4 !~ /N/ && $4 !~ /-/' {input} > {output}"
 
 
 # determine max kmer frequency using jellyfish


### PR DESCRIPTION
The existing `filter_n_probes` Snakemake rule already filters out any homology sequence candidates containing "N" characters. After this change, this step also filters out any sequence candidates containing "-" characters, preventing these sequences from going into downstream steps where these characters are problematic.