### PR TITLE
expose min_tm and max_tm blockparse params in snakemake config file

### DIFF
--- a/example_run/config.yml
+++ b/example_run/config.yml
@@ -22,6 +22,8 @@ annotation_file: 'data/example.gtf'
 # blockparse params (initial probe candidate mining)
 # blockparse_min_length: 30
 # blockparse_max_length: 37
+# blockparse_min_tm: 42
+# blockparse_max_tm: 47
 
 # number of threads for bowtie2 to use
 # bowtie2_threads: 4

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -162,8 +162,10 @@ rule design_probes:
         basename='pipeline_output/02_intermediate_files/02_init_probes/{chrom}',
         min_length=config.get('blockparse_min_length', 30),
         max_length=config.get('blockparse_max_length', 37),
+        min_tm=config.get('blockparse_min_tm', 42),
+        max_tm=config.get('blockparse_max_tm', 47)
     shell:
-        'python {workflow.basedir}/scripts/blockParse_unmasked.py -l {params.min_length} -L {params.max_length} -f {input[0]} -o {params.basename}'
+        'python {workflow.basedir}/scripts/blockParse_unmasked.py -l {params.min_length} -L {params.max_length} -t {params.min_tm} -T {params.max_tm} -f {input[0]} -o {params.basename}'
 
 # optional: if the user provided probes, skip probe mining and format those as fastq files
 rule format_existing_probes:


### PR DESCRIPTION
Previously, the `min_tm` and `max_tm` parameters in the blockParse_unmasked.py script (for the `design_probes` Snakemake rule) were hard-coded (as argparse defaults in the python script). After this change, these parameters are exposed in the Snakemake config.yml file and can be uncommented and over-ridden per run.